### PR TITLE
update ceilometer api for http

### DIFF
--- a/puppet/modules/eayunstack/files/app.wsgi
+++ b/puppet/modules/eayunstack/files/app.wsgi
@@ -1,0 +1,27 @@
+# -*- mode: python -*-
+#
+# Copyright 2013 New Dream Network, LLC (DreamHost)
+#
+# Author: Doug Hellmann <doug.hellmann@dreamhost.com>
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+"""Use this file for deploying the API under mod_wsgi.
+
+See http://pecan.readthedocs.org/en/latest/deployment.html for details.
+"""
+from ceilometer import service
+from ceilometer.api import app
+
+# Initialize the oslo configuration library and logging
+service.prepare_service([])
+application = app.load_app()

--- a/puppet/modules/eayunstack/manifests/upgrade.pp
+++ b/puppet/modules/eayunstack/manifests/upgrade.pp
@@ -1,7 +1,7 @@
 class eayunstack::upgrade (
   $fuel_settings,
 ) {
-  class { 'eayunstack::upgrade::ceilometer':
+  class { 'eayunstack::upgrade::ceilometer::ceilometer':
     fuel_settings => $fuel_settings,
   }
   class { 'eayunstack::upgrade::cinder':

--- a/puppet/modules/eayunstack/templates/ceilometer_http.conf.erb
+++ b/puppet/modules/eayunstack/templates/ceilometer_http.conf.erb
@@ -1,0 +1,24 @@
+# THIS FILE IS MANAGED BY PUPPET USE CEILOMETER HTTP CONFIGURE
+# <%= file %>
+#
+
+<% if @memorysize_mb.to_i < 1200 or @processorcount.to_i <= 3 %>
+  wsgi_daemon_processes = 3
+  wsgi_daemon_threads = 10
+<% else %>
+  wsgi_daemon_processes = @processorcount
+  wsgi_daemon_threads = 15
+<% end %>
+
+Listen 8777
+
+<VirtualHost *.8777>
+  WSGIDaemonProcess ceilometer-api user=ceilometer group=ceilometer processes=<%= wsgi_daemon_processes %> threads=<% wsgi_daemon_threads %>
+  WSGIScriptAlias / /var/www/ceilometer/app.wsgi
+  SetEnv APACHE_RUN_USER ceilometer
+  SetEnv APACHE_RUN_GROUP ceilometer
+  WSGIProcessGroup ceilometer-api
+  ErrorLog /var/log/httpd/ceilometer_error.log
+  LogLevel warn
+  CustomLog /var/log/httpd/ceilometer_access.log combined
+</VirtualHost>


### PR DESCRIPTION
This file use ceilometer upgrade and ceilometer api update openstack-ceilometer-api to httpd service
Two question topic:
1. app.wsgi 为一个ceilometer httpd 使用文件，文件名称在httpd调用时就使用app.wsgi文件
2. 关于httpd服务，目前ceilometer 通过httpd 加载app.wsgi启动ceilometer api服务，httpd本身没有更新，唯一的依赖即为，ceilometer.conf配置文件更新后，需要http重启进行加载。

Signed-off-by: fabian cybing4@gmail.com
