### PR TITLE
update ceilometer api for http

### DIFF
--- a/puppet/modules/eayunstack/files/ceilometer.wsgi
+++ b/puppet/modules/eayunstack/files/ceilometer.wsgi
@@ -1,0 +1,27 @@
+# -*- mode: python -*-
+#
+# Copyright 2013 New Dream Network, LLC (DreamHost)
+#
+# Author: Doug Hellmann <doug.hellmann@dreamhost.com>
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+"""Use this file for deploying the API under mod_wsgi.
+
+See http://pecan.readthedocs.org/en/latest/deployment.html for details.
+"""
+from ceilometer import service
+from ceilometer.api import app
+
+# Initialize the oslo configuration library and logging
+service.prepare_service([])
+application = app.load_app()

--- a/puppet/modules/eayunstack/manifests/upgrade.pp
+++ b/puppet/modules/eayunstack/manifests/upgrade.pp
@@ -1,7 +1,7 @@
 class eayunstack::upgrade (
   $fuel_settings,
 ) {
-  class { 'eayunstack::upgrade::ceilometer':
+  class { 'eayunstack::upgrade::ceilometer::ceilometer':
     fuel_settings => $fuel_settings,
   }
   class { 'eayunstack::upgrade::cinder':

--- a/puppet/modules/eayunstack/manifests/upgrade/ceilometer/ceilometer.pp
+++ b/puppet/modules/eayunstack/manifests/upgrade/ceilometer/ceilometer.pp
@@ -17,18 +17,9 @@ class eayunstack::upgrade::ceilometer (
     package { $packages[controller]:
       ensure => latest,
     }
-
-    augeas { 'add-ceilometer-api':
-      context => '/files/etc/ceilometer/ceilometer.conf',
-      lens => 'Puppet.lns',
-      incl => '/etc/ceilometer/ceilometer.conf',
-      changes => [
-        "set DEFAULT/api_workers  $::processorcount",
-      ],
-    }
     $systemd_services = [
-      'openstack-ceilometer-alarm-notifier', 'openstack-ceilometer-api',
-      'openstack-ceilometer-collector', 'openstack-ceilometer-notification',
+      'openstack-ceilometer-alarm-notifier', 'openstack-ceilometer-collector',
+      'openstack-ceilometer-notification',
     ]
 
     service { $systemd_services:
@@ -47,6 +38,41 @@ class eayunstack::upgrade::ceilometer (
       provider => 'pacemaker',
     }
 
+    service { 'openstack-ceilometer-api':
+      ensure => stopped,
+      enable => false,
+    }
+
+    file { '/var/www/ceilometer/':
+      ensure => directory,
+    }
+
+    file { 'ceilometer.wsgi':
+      path => '/var/www/ceilometer/ceilometer.wsgi',
+      source => 'puppet:///modules/eayunstack/ceilometer.wsgi',
+      require => File['/var/www/ceilometer/'],
+    }
+
+    file { 'openstack-ceilometer.conf':
+      path => '/etc/httpd/conf.d/openstack-ceilometer.conf',
+      ensure => file,
+      content => template('eayunstack/ceilometer_http_conf.erb'),
+    }
+
+    augeas { 'ceilometer-update-debug':
+      context => '/files/etc/ceilometer/ceilometer.conf',
+      lens => 'Puppet.lns',
+      incl => '/etc/ceilometer/ceilometer.conf',
+      changes => [
+        "set default/debug False",
+        "set api/pecan_debug False",
+      ],
+    }
+    service { 'httpd':
+      ensure => running,
+      enable => true,
+    }
+
     Package['openstack-ceilometer-alarm'] ~>
       Service['openstack-ceilometer-alarm-notifier']
     Package['openstack-ceilometer-notification'] ~>
@@ -54,8 +80,10 @@ class eayunstack::upgrade::ceilometer (
     Package['openstack-ceilometer-collector'] ~>
       Service['openstack-ceilometer-collector']
     Package['openstack-ceilometer-api'] ~>
-      Augeas['add-ceilometer-api'] ~>
-        Service['openstack-ceilometer-api']
+      Service['openstack-ceilometer-api'] ~>
+        File['openstack-ceilometer.conf'] ~>
+          Augeas['ceilometer-update-debug'] ~>
+            Service['httpd']
     Package['openstack-ceilometer-central'] ~>
       Service['openstack-ceilometer-central']
     Package['openstack-ceilometer-alarm'] ~>

--- a/puppet/modules/eayunstack/templates/ceilometer_http_conf.erb
+++ b/puppet/modules/eayunstack/templates/ceilometer_http_conf.erb
@@ -1,0 +1,24 @@
+# THIS FILE IS MANAGED BY PUPPET USE CEILOMETER HTTP CONFIGURE
+# <%= file %>
+#
+
+<% if @memorysize_mb.to_i < 1200 or @processorcount.to_i <= 3 %>
+  wsgi_daemon_processes = 3
+  wsgi_daemon_threads = 10
+<% else %>
+  wsgi_daemon_processes = @processorcount
+  wsgi_daemon_threads = 15
+<% end %>
+
+Listen 8777
+
+<VirtualHost *.8777>
+  WSGIDaemonProcess ceilometer-api user=ceilometer group=ceilometer processes=<%= wsgi_daemon_processes %> threads=<% wsgi_daemon_threads %>
+  WSGIScriptAlias / /var/www/ceilometer/ceilometer.wsgi
+  SetEnv APACHE_RUN_USER ceilometer
+  SetEnv APACHE_RUN_GROUP ceilometer
+  WSGIProcessGroup ceilometer-api
+  ErrorLog /var/log/httpd/ceilometer_error.log
+  LogLevel warn
+  CustomLog /var/log/httpd/ceilometer_access.log combined
+</VirtualHost>


### PR DESCRIPTION
This file use ceilometer upgrade and ceilometer api update openstack-ceilometer-api to httpd service
Two question topic:
1.  关于httpd服务，目前ceilometer 通过httpd 加载ceilometer.wsgi启动ceilometer api服务，httpd本身没有更新，唯一的依赖即为，ceilometer.conf配置文件更新后，需要httpd重启进行加载。

Signed-off-by: fabian cybing4@gmail.com
