### PR TITLE
update ceilometer mongodb connection configure

### DIFF
--- a/puppet/modules/eayunstack/lib/puppet/parser/functions/get_mongodb_connection.rb
+++ b/puppet/modules/eayunstack/lib/puppet/parser/functions/get_mongodb_connection.rb
@@ -1,0 +1,22 @@
+module Puppet::Parser::Functions
+  newfunction(:get_mongodb_connection, :type => :rvalue) do |args|
+    mongo_ip = "#{args[0]}:27017"
+    mongo_password = args[1]
+    script = <<-END_SCRIPT
+from pymongo import MongoClient
+
+try:
+    mc = MongoClient('mongodb://admin:#{mongo_password}@#{mongo_ip}/admin')
+    doc = mc.admin.command('isMaster')
+    hosts = doc.get('hosts', ['#{mongo_ip}'])
+except:
+    hosts = ['#{mongo_ip}']
+
+print 'mongodb://ceilometer:%s@%s/ceilometer' % (
+   '#{mongo_password}', ','.join(hosts)
+)
+END_SCRIPT
+
+    `python -c "#{script}"`.strip!
+  end
+end


### PR DESCRIPTION
目前没有测试astute.yaml文件中添加mongo节点信息后，下次新增controller节点或其它节点后astute.yaml文件中增加的Mongo信息会不会丢失，因此目前采用手动静态方式，等待以后调整为自动获取mongo 的IP地址．

Signed-off-by: fabian cybing4@gmail.com
