### PR TITLE
python-eventlet: fix wrong package name when upgrading compute nodes.

### DIFF
--- a/puppet/modules/eayunstack/manifests/upgrade/python-eventlet.pp
+++ b/puppet/modules/eayunstack/manifests/upgrade/python-eventlet.pp
@@ -16,7 +16,7 @@ class eayunstack::upgrade::python-eventlet (
 
   } elsif $eayunstack_node_role == 'compute' {
 
-    Package['python-oslo-messaging'] ~>
+    Package['python-eventlet'] ~>
       Service[$::eayunstack::generic::openstack_services['compute']]
 
     # There is no service on ceph-osd to be restarted.


### PR DESCRIPTION
Signed-off-by: Zhao Chao zhaochao1984@gmail.com
