### PR TITLE
reset ceph auth for nova user

### DIFF
--- a/puppet/modules/eayunstack/lib/puppet/parser/functions/get_ceph_auth_info.rb
+++ b/puppet/modules/eayunstack/lib/puppet/parser/functions/get_ceph_auth_info.rb
@@ -1,0 +1,17 @@
+require 'json'
+
+module Puppet::Parser::Functions
+  newfunction(:get_ceph_auth_info, :type => :rvalue) do |args|
+    entity = args[0]
+    daemon_type = args[1]
+    caps = ''
+    auth_list = `/usr/bin/ceph -f json auth list`.strip
+    auth_json = JSON.parse(auth_list)
+    auth_json['auth_dump'].each do |auth|
+      if auth['entity'] == entity
+        caps = auth['caps'][daemon_type]
+      end
+    end
+    return caps
+  end
+end

--- a/puppet/modules/eayunstack/lib/puppet/parser/functions/modify_ceph_auth_info.rb
+++ b/puppet/modules/eayunstack/lib/puppet/parser/functions/modify_ceph_auth_info.rb
@@ -1,0 +1,18 @@
+module Puppet::Parser::Functions
+  newfunction(:modify_ceph_auth_info, :type => :rvalue) do |args|
+    entity = args[0]
+    daemon_type = args[1]
+    old_cap = args[2]
+    new_cap = args[3]
+    old_caps = ''
+    auth_list = `/usr/bin/ceph -f json auth list`.strip
+    auth_json = JSON.parse(auth_list)
+    auth_json['auth_dump'].each do |auth|
+      if auth['entity'] == entity
+        old_caps = auth['caps'][daemon_type]
+      end
+    end
+    new_caps = old_caps.gsub(old_cap, new_cap)
+    return new_caps
+  end
+end

--- a/puppet/modules/eayunstack/manifests/upgrade.pp
+++ b/puppet/modules/eayunstack/manifests/upgrade.pp
@@ -6,6 +6,9 @@ class eayunstack::upgrade (
   class { 'eayunstack::upgrade::ceilometer::ceilometer':
     fuel_settings => $fuel_settings,
   }
+  class { 'eayunstack::upgrade::ceph':
+    fuel_settings => $fuel_settings,
+  }
   class { 'eayunstack::upgrade::cinder':
     fuel_settings => $fuel_settings,
   }

--- a/puppet/modules/eayunstack/manifests/upgrade/ceph.pp
+++ b/puppet/modules/eayunstack/manifests/upgrade/ceph.pp
@@ -1,0 +1,16 @@
+class eayunstack::upgrade::ceph (
+  $fuel_settings,
+) {
+  if $eayunstack_node_role == 'controller' {
+    # just get current mon acl, without any modification
+    $ceph_mon_caps = get_ceph_auth_info('client.compute', 'mon')
+    # modify user 'compute''s access permission from 'rx' to 'rwx' for images pool
+    $ceph_osd_caps = modify_ceph_auth_info('client.compute', 'osd', 'allow rx pool=images', 'allow rwx pool=images')
+    exec {'reset-cephx-acl-for-user-compute':
+      path => '/usr/bin/',
+      command => "ceph auth caps client.compute mon '${ceph_mon_caps}' osd '${ceph_osd_caps}'",
+      tries       => 10,
+      try_sleep   => 20,
+    }
+  }
+}


### PR DESCRIPTION
For the optimization of create snapshot from instance, nova user(client.compute) needs to have write access to the images pool.

Signed-off-by: blkart blkart.org@gmail.com
