### PR TITLE
Codestyle

### DIFF
--- a/puppet/modules/eayunstack/manifests/upgrade.pp
+++ b/puppet/modules/eayunstack/manifests/upgrade.pp
@@ -39,7 +39,7 @@ class eayunstack::upgrade (
   class { 'eayunstack::upgrade::oslo::messaging':
     fuel_settings => $fuel_settings,
   }
-  class { 'eayunstack::upgrade::python-eventlet':
+  class { 'eayunstack::upgrade::python_eventlet':
     fuel_settings => $fuel_settings,
   }
 }

--- a/puppet/modules/eayunstack/manifests/upgrade/ceilometer/ceilometer.pp
+++ b/puppet/modules/eayunstack/manifests/upgrade/ceilometer/ceilometer.pp
@@ -50,7 +50,7 @@ class eayunstack::upgrade::ceilometer::ceilometer (
       lens => 'Puppet.lns',
       incl => '/etc/ceilometer/ceilometer.conf',
       changes => [
-        "set DEFAULT/api_workers  $::processorcount",
+        "set DEFAULT/api_workers  ${::processorcount}",
         'set DEFAULT/debug False',
         'set DEFAULT/pipeline_cfg_file /etc/ceilometer/pipeline.yaml',
         'set api/pecan_debug False',
@@ -74,7 +74,7 @@ class eayunstack::upgrade::ceilometer::ceilometer (
       lens => 'Puppet.lns',
       incl => '/etc/ceilometer/ceilometer.conf',
       changes => [
-        "set database/connection $mongodb_connection",
+        "set database/connection ${mongodb_connection}",
       ],
       require => Package['openstack-ceilometer-common'],
       notify => [

--- a/puppet/modules/eayunstack/manifests/upgrade/ceilometer/ceilometer.pp
+++ b/puppet/modules/eayunstack/manifests/upgrade/ceilometer/ceilometer.pp
@@ -51,11 +51,11 @@ class eayunstack::upgrade::ceilometer::ceilometer (
       incl => '/etc/ceilometer/ceilometer.conf',
       changes => [
         "set DEFAULT/api_workers  $::processorcount",
-        "set DEFAULT/debug False",
-        "set DEFAULT/pipeline_cfg_file /etc/ceilometer/pipeline.yaml",
-        "set api/pecan_debug False",
-        "set event/definitions_cfg_file /etc/ceilometer/event_definitions.yaml",
-        "set notification/store_events True",
+        'set DEFAULT/debug False',
+        'set DEFAULT/pipeline_cfg_file /etc/ceilometer/pipeline.yaml',
+        'set api/pecan_debug False',
+        'set event/definitions_cfg_file /etc/ceilometer/event_definitions.yaml',
+        'set notification/store_events True',
       ],
       require => [
         Package['openstack-ceilometer-common'],
@@ -156,7 +156,7 @@ class eayunstack::upgrade::ceilometer::ceilometer (
       lens => 'Puppet.lns',
       incl => '/etc/ceilometer/ceilometer.conf',
       changes => [
-        "set DEFAULT/pipeline_cfg_file /etc/ceilometer/pipeline.yaml",
+        'set DEFAULT/pipeline_cfg_file /etc/ceilometer/pipeline.yaml',
       ],
       require => [
         Package['openstack-ceilometer-common'],

--- a/puppet/modules/eayunstack/manifests/upgrade/ceilometer/ceilometer.pp
+++ b/puppet/modules/eayunstack/manifests/upgrade/ceilometer/ceilometer.pp
@@ -26,29 +26,29 @@ class eayunstack::upgrade::ceilometer::ceilometer (
     }
 
     file { 'pipeline.yaml':
-      ensure => file,
-      path => '/etc/ceilometer/pipeline.yaml',
-      source => 'puppet:///modules/eayunstack/pipeline.yaml',
-      group => 'ceilometer',
+      ensure  => file,
+      path    => '/etc/ceilometer/pipeline.yaml',
+      source  => 'puppet:///modules/eayunstack/pipeline.yaml',
+      group   => 'ceilometer',
       require => Package['openstack-ceilometer-common'],
-      notify => [
+      notify  => [
         Service['openstack-ceilometer-notification'], Service['openstack-ceilometer-api'],
         Service['httpd'], Service['openstack-ceilometer-central'],
       ],
     }
     file { 'event_definitions.yaml':
-      ensure => file,
-      path => '/etc/ceilometer/event_definitions.yaml',
-      source => 'puppet:///modules/eayunstack/event_definitions.yaml',
-      group => 'ceilometer',
+      ensure  => file,
+      path    => '/etc/ceilometer/event_definitions.yaml',
+      source  => 'puppet:///modules/eayunstack/event_definitions.yaml',
+      group   => 'ceilometer',
       require => Package['openstack-ceilometer-common'],
-      notify => Service['openstack-ceilometer-notification'],
+      notify  => Service['openstack-ceilometer-notification'],
     }
 
     augeas { 'ceilometer-conf':
       context => '/files/etc/ceilometer/ceilometer.conf',
-      lens => 'Puppet.lns',
-      incl => '/etc/ceilometer/ceilometer.conf',
+      lens    => 'Puppet.lns',
+      incl    => '/etc/ceilometer/ceilometer.conf',
       changes => [
         "set DEFAULT/api_workers  ${::processorcount}",
         'set DEFAULT/debug False',
@@ -61,7 +61,7 @@ class eayunstack::upgrade::ceilometer::ceilometer (
         Package['openstack-ceilometer-common'],
         File['pipeline.yaml', 'event_definitions.yaml'],
       ],
-      notify => [
+      notify  => [
         Service['openstack-ceilometer-api'],
         Service['openstack-ceilometer-central'],
         Service['openstack-ceilometer-notification'],
@@ -71,13 +71,13 @@ class eayunstack::upgrade::ceilometer::ceilometer (
 
     augeas { 'ceilometer-database':
       context => '/files/etc/ceilometer/ceilometer.conf',
-      lens => 'Puppet.lns',
-      incl => '/etc/ceilometer/ceilometer.conf',
+      lens    => 'Puppet.lns',
+      incl    => '/etc/ceilometer/ceilometer.conf',
       changes => [
         "set database/connection ${mongodb_connection}",
       ],
       require => Package['openstack-ceilometer-common'],
-      notify => [
+      notify  => [
         Service['openstack-ceilometer-collector'],
         Service['openstack-ceilometer-api'],
         Service['httpd'],
@@ -98,11 +98,11 @@ class eayunstack::upgrade::ceilometer::ceilometer (
       'openstack-ceilometer-central', 'openstack-ceilometer-alarm-evaluator',
     ]
     service { $pcs_services:
-      ensure => running,
-      enable => true,
-      hasstatus => true,
+      ensure     => running,
+      enable     => true,
+      hasstatus  => true,
       hasrestart => false,
-      provider => 'pacemaker',
+      provider   => 'pacemaker',
     }
 
     service { 'openstack-ceilometer-api':
@@ -143,18 +143,18 @@ class eayunstack::upgrade::ceilometer::ceilometer (
     }
 
     file { 'pipeline.yaml':
-      ensure => file,
-      path => '/etc/ceilometer/pipeline.yaml',
-      source => 'puppet:///modules/eayunstack/pipeline.yaml',
-      group => 'ceilometer',
+      ensure  => file,
+      path    => '/etc/ceilometer/pipeline.yaml',
+      source  => 'puppet:///modules/eayunstack/pipeline.yaml',
+      group   => 'ceilometer',
       require => Package['openstack-ceilometer-common'],
-      notify => Service['openstack-ceilometer-compute'],
+      notify  => Service['openstack-ceilometer-compute'],
     }
 
     augeas { 'ceilometer-pipeline':
       context => '/files/etc/ceilometer/ceilometer.conf',
-      lens => 'Puppet.lns',
-      incl => '/etc/ceilometer/ceilometer.conf',
+      lens    => 'Puppet.lns',
+      incl    => '/etc/ceilometer/ceilometer.conf',
       changes => [
         'set DEFAULT/pipeline_cfg_file /etc/ceilometer/pipeline.yaml',
       ],
@@ -162,7 +162,7 @@ class eayunstack::upgrade::ceilometer::ceilometer (
         Package['openstack-ceilometer-common'],
         File['pipeline.yaml'],
       ],
-      notify => Service['openstack-ceilometer-compute'],
+      notify  => Service['openstack-ceilometer-compute'],
     }
 
     Package['openstack-ceilometer-compute'] ~>

--- a/puppet/modules/eayunstack/manifests/upgrade/ceilometer/ceilometer.pp
+++ b/puppet/modules/eayunstack/manifests/upgrade/ceilometer/ceilometer.pp
@@ -26,8 +26,8 @@ class eayunstack::upgrade::ceilometer::ceilometer (
     }
 
     file { 'pipeline.yaml':
-      path => '/etc/ceilometer/pipeline.yaml',
       ensure => file,
+      path => '/etc/ceilometer/pipeline.yaml',
       source => 'puppet:///modules/eayunstack/pipeline.yaml',
       group => 'ceilometer',
       require => Package['openstack-ceilometer-common'],
@@ -37,8 +37,8 @@ class eayunstack::upgrade::ceilometer::ceilometer (
       ],
     }
     file { 'event_definitions.yaml':
-      path => '/etc/ceilometer/event_definitions.yaml',
       ensure => file,
+      path => '/etc/ceilometer/event_definitions.yaml',
       source => 'puppet:///modules/eayunstack/event_definitions.yaml',
       group => 'ceilometer',
       require => Package['openstack-ceilometer-common'],
@@ -143,8 +143,8 @@ class eayunstack::upgrade::ceilometer::ceilometer (
     }
 
     file { 'pipeline.yaml':
-      path => '/etc/ceilometer/pipeline.yaml',
       ensure => file,
+      path => '/etc/ceilometer/pipeline.yaml',
       source => 'puppet:///modules/eayunstack/pipeline.yaml',
       group => 'ceilometer',
       require => Package['openstack-ceilometer-common'],

--- a/puppet/modules/eayunstack/manifests/upgrade/ceph.pp
+++ b/puppet/modules/eayunstack/manifests/upgrade/ceph.pp
@@ -7,10 +7,10 @@ class eayunstack::upgrade::ceph (
     # modify user 'compute''s access permission from 'rx' to 'rwx' for images pool
     $ceph_osd_caps = modify_ceph_auth_info('client.compute', 'osd', 'allow rx pool=images', 'allow rwx pool=images')
     exec {'reset-cephx-acl-for-user-compute':
-      path => '/usr/bin/',
-      command => "ceph auth caps client.compute mon '${ceph_mon_caps}' osd '${ceph_osd_caps}'",
-      tries       => 10,
-      try_sleep   => 20,
+      path      => '/usr/bin/',
+      command   => "ceph auth caps client.compute mon '${ceph_mon_caps}' osd '${ceph_osd_caps}'",
+      tries     => 10,
+      try_sleep => 20,
     }
   }
 }

--- a/puppet/modules/eayunstack/manifests/upgrade/glance.pp
+++ b/puppet/modules/eayunstack/manifests/upgrade/glance.pp
@@ -14,24 +14,24 @@ class eayunstack::upgrade::glance (
 
     augeas { 'glance-api':
       context => '/files/etc/glance/glance-api.conf',
-      lens => 'Puppet.lns',
-      incl => '/etc/glance/glance-api.conf',
+      lens    => 'Puppet.lns',
+      incl    => '/etc/glance/glance-api.conf',
       changes => [
         'set DEFAULT/notification_driver messaging',
       ],
       require => Package['openstack-glance'],
-      notify => Service['openstack-glance-api'],
+      notify  => Service['openstack-glance-api'],
     }
 
     augeas { 'glance-registry':
       context => '/files/etc/glance/glance-registry.conf',
-      lens => 'Puppet.lns',
-      incl => '/etc/glance/glance-registry.conf',
+      lens    => 'Puppet.lns',
+      incl    => '/etc/glance/glance-registry.conf',
       changes => [
         'set DEFAULT/notification_driver messaging',
       ],
       require => Package['openstack-glance'],
-      notify => Service['openstack-glance-registry'],
+      notify  => Service['openstack-glance-registry'],
     }
     $systemd_services = [
       'openstack-glance-api', 'openstack-glance-registry',

--- a/puppet/modules/eayunstack/manifests/upgrade/glance.pp
+++ b/puppet/modules/eayunstack/manifests/upgrade/glance.pp
@@ -17,7 +17,7 @@ class eayunstack::upgrade::glance (
       lens => 'Puppet.lns',
       incl => '/etc/glance/glance-api.conf',
       changes => [
-        "set DEFAULT/notification_driver messaging",
+        'set DEFAULT/notification_driver messaging',
       ],
       require => Package['openstack-glance'],
       notify => Service['openstack-glance-api'],
@@ -28,7 +28,7 @@ class eayunstack::upgrade::glance (
       lens => 'Puppet.lns',
       incl => '/etc/glance/glance-registry.conf',
       changes => [
-        "set DEFAULT/notification_driver messaging",
+        'set DEFAULT/notification_driver messaging',
       ],
       require => Package['openstack-glance'],
       notify => Service['openstack-glance-registry'],

--- a/puppet/modules/eayunstack/manifests/upgrade/haproxy/haproxy.pp
+++ b/puppet/modules/eayunstack/manifests/upgrade/haproxy/haproxy.pp
@@ -10,25 +10,25 @@ class eayunstack::upgrade::haproxy::haproxy (
 
     $pcs_services = ['haproxy']
     service { $pcs_services:
-      ensure => running,
-      enable => true,
-      hasstatus => true,
+      ensure     => running,
+      enable     => true,
+      hasstatus  => true,
       hasrestart => false,
-      provider => 'pacemaker',
+      provider   => 'pacemaker',
     }
 
     file { 'haproxy_directory':
-      ensure => directory,
-      path => '/etc/haproxy/conf.d',
+      ensure  => directory,
+      path    => '/etc/haproxy/conf.d',
       require => Package['haproxy'],
     }
 
     file { 'haproxy_ceilometer':
-      ensure => file,
-      path => '/etc/haproxy/conf.d/140-ceilometer.cfg',
+      ensure  => file,
+      path    => '/etc/haproxy/conf.d/140-ceilometer.cfg',
       content => template('eayunstack/haproxy_ceilometer.erb'),
       require => File['haproxy_directory'],
-      notify => Service['haproxy'],
+      notify  => Service['haproxy'],
     }
 
     Package['haproxy'] ~>

--- a/puppet/modules/eayunstack/manifests/upgrade/haproxy/haproxy.pp
+++ b/puppet/modules/eayunstack/manifests/upgrade/haproxy/haproxy.pp
@@ -18,14 +18,14 @@ class eayunstack::upgrade::haproxy::haproxy (
     }
 
     file { 'haproxy_directory':
-      path => '/etc/haproxy/conf.d',
       ensure => directory,
+      path => '/etc/haproxy/conf.d',
       require => Package['haproxy'],
     }
 
     file { 'haproxy_ceilometer':
-      path => '/etc/haproxy/conf.d/140-ceilometer.cfg',
       ensure => file,
+      path => '/etc/haproxy/conf.d/140-ceilometer.cfg',
       content => template('eayunstack/haproxy_ceilometer.erb'),
       require => File['haproxy_directory'],
       notify => Service['haproxy'],

--- a/puppet/modules/eayunstack/manifests/upgrade/http/http_ceilometer.pp
+++ b/puppet/modules/eayunstack/manifests/upgrade/http/http_ceilometer.pp
@@ -17,8 +17,8 @@ class eayunstack::upgrade::http::http_ceilometer(
     }
 
     file { 'http-ceilometer.conf':
-      path => '/etc/httpd/conf.d/openstack-ceilometer.conf',
       ensure => file,
+      path => '/etc/httpd/conf.d/openstack-ceilometer.conf',
       content => template('eayunstack/ceilometer_http.erb'),
       require => File['ceilometer.wsgi'],
       notify => Service['httpd']

--- a/puppet/modules/eayunstack/manifests/upgrade/http/http_ceilometer.pp
+++ b/puppet/modules/eayunstack/manifests/upgrade/http/http_ceilometer.pp
@@ -7,21 +7,21 @@ class eayunstack::upgrade::http::http_ceilometer(
       ensure => latest,
     }
     file { '/var/www/ceilometer/':
-      ensure => directory,
+      ensure  => directory,
       require => Package['httpd']
     }
     file { 'ceilometer.wsgi':
-      path => '/var/www/ceilometer/ceilometer.wsgi',
-      source => 'puppet:///modules/eayunstack/ceilometer.wsgi',
+      path    => '/var/www/ceilometer/ceilometer.wsgi',
+      source  => 'puppet:///modules/eayunstack/ceilometer.wsgi',
       require => File['/var/www/ceilometer/'],
     }
 
     file { 'http-ceilometer.conf':
-      ensure => file,
-      path => '/etc/httpd/conf.d/openstack-ceilometer.conf',
+      ensure  => file,
+      path    => '/etc/httpd/conf.d/openstack-ceilometer.conf',
       content => template('eayunstack/ceilometer_http.erb'),
       require => File['ceilometer.wsgi'],
-      notify => Service['httpd']
+      notify  => Service['httpd']
     }
 
     service { 'httpd':

--- a/puppet/modules/eayunstack/manifests/upgrade/neutron.pp
+++ b/puppet/modules/eayunstack/manifests/upgrade/neutron.pp
@@ -78,13 +78,13 @@ class eayunstack::upgrade::neutron (
     }
 
     file { 'replace-neutron-l3-agent':
-      path   => "/usr/bin/neutron-l3-agent",
+      path   => '/usr/bin/neutron-l3-agent',
       ensure => file,
       backup => '.bak',
       mode   => '0755',
       owner  => 'root',
       group  => 'root',
-      source => "/usr/bin/neutron-vpn-agent"
+      source => '/usr/bin/neutron-vpn-agent',
     }
 
     file { 'ppp-dir':

--- a/puppet/modules/eayunstack/manifests/upgrade/neutron.pp
+++ b/puppet/modules/eayunstack/manifests/upgrade/neutron.pp
@@ -26,11 +26,11 @@ class eayunstack::upgrade::neutron (
       'neutron-metadata-agent', 'neutron-lbaas-agent',
     ]
     service { $pcs_services:
-      ensure => running,
-      enable => true,
-      hasstatus => true,
+      ensure     => running,
+      enable     => true,
+      hasstatus  => true,
       hasrestart => false,
-      provider => 'pacemaker',
+      provider   => 'pacemaker',
     }
 
     exec { 'database-upgrade':
@@ -43,28 +43,28 @@ class eayunstack::upgrade::neutron (
 
     augeas { 'add-pptp-vpn-service-provider':
       context => '/files/etc/neutron/neutron.conf',
-      lens => 'Puppet.lns',
-      incl => '/etc/neutron/neutron.conf',
+      lens    => 'Puppet.lns',
+      incl    => '/etc/neutron/neutron.conf',
       changes => [
         'set service_providers/service_provider[last()+1] VPN:pptp:neutron.services.vpn.service_drivers.pptp.PPTPVPNDriver'
       ],
-      onlyif => 'match service_providers/service_provider[.="VPN:pptp:neutron.services.vpn.service_drivers.pptp.PPTPVPNDriver"] size < 1',
+      onlyif  => 'match service_providers/service_provider[.="VPN:pptp:neutron.services.vpn.service_drivers.pptp.PPTPVPNDriver"] size < 1',
     }
 
     augeas { 'add-pptp-vpn-device-driver':
       context => '/files/etc/neutron/l3_agent.ini',
-      lens => 'Puppet.lns',
-      incl => '/etc/neutron/l3_agent.ini',
+      lens    => 'Puppet.lns',
+      incl    => '/etc/neutron/l3_agent.ini',
       changes => [
         'set vpnagent/vpn_device_driver[last()+1] neutron.services.vpn.device_drivers.pptp.PPTPDriver'
       ],
-      onlyif => 'match vpnagent/vpn_device_driver[.="neutron.services.vpn.device_drivers.pptp.PPTPDriver"] size < 1',
+      onlyif  => 'match vpnagent/vpn_device_driver[.="neutron.services.vpn.device_drivers.pptp.PPTPDriver"] size < 1',
     }
 
     augeas { 'metering-agent':
       context => '/files/etc/neutron/metering_agent.ini',
-      lens => 'Puppet.lns',
-      incl => '/etc/neutron/metering_agent.ini',
+      lens    => 'Puppet.lns',
+      incl    => '/etc/neutron/metering_agent.ini',
       changes => [
           'set DEFAULT/debug True',
           'set DEFAULT/driver neutron.services.metering.drivers.iptables.iptables_driver.IptablesMeteringDriver',
@@ -74,7 +74,7 @@ class eayunstack::upgrade::neutron (
           'set DEFAULT/use_namespaces True',
         ],
       require => Package['openstack-neutron-metering-agent'],
-      notify => Service['neutron-metering-agent'],
+      notify  => Service['neutron-metering-agent'],
     }
 
     file { 'replace-neutron-l3-agent':
@@ -89,25 +89,25 @@ class eayunstack::upgrade::neutron (
 
     file { 'ppp-dir':
       ensure => directory,
-      path => '/etc/ppp',
-      owner => 'neutron',
-      group => 'root',
+      path   => '/etc/ppp',
+      owner  => 'neutron',
+      group  => 'root',
     }
 
     file { 'ppp-chap-secrets':
       ensure => file,
-      path => '/etc/ppp/chap-secrets',
-      mode => '0644',
-      owner => 'neutron',
-      group => 'neutron',
+      path   => '/etc/ppp/chap-secrets',
+      mode   => '0644',
+      owner  => 'neutron',
+      group  => 'neutron',
     }
 
     $ip_local_files = ['ip-up.local', 'ip-down.local']
     file { $ip_local_files:
       ensure => file,
-      mode => '0755',
-      owner => 'root',
-      group => 'root',
+      mode   => '0755',
+      owner  => 'root',
+      group  => 'root',
     }
     File['ip-up.local'] {
       path => '/etc/ppp/ip-up.local',
@@ -120,11 +120,11 @@ class eayunstack::upgrade::neutron (
 
     file { 'replace-q-agent-cleanup':
       ensure => file,
-      path => '/usr/bin/q-agent-cleanup.py',
+      path   => '/usr/bin/q-agent-cleanup.py',
       backup => '.bak',
-      mode => '0755',
-      owner => 'root',
-      group => 'root',
+      mode   => '0755',
+      owner  => 'root',
+      group  => 'root',
       source => 'puppet:///modules/eayunstack/q-agent-cleanup.py',
     }
 

--- a/puppet/modules/eayunstack/manifests/upgrade/neutron.pp
+++ b/puppet/modules/eayunstack/manifests/upgrade/neutron.pp
@@ -125,7 +125,7 @@ class eayunstack::upgrade::neutron (
       mode => '0755',
       owner => 'root',
       group => 'root',
-      source => 'puppet://modules/eayunstack/q-agent-cleanup.py',
+      source => 'puppet:///modules/eayunstack/q-agent-cleanup.py',
     }
 
     Package['openstack-neutron-ml2'] {

--- a/puppet/modules/eayunstack/manifests/upgrade/neutron.pp
+++ b/puppet/modules/eayunstack/manifests/upgrade/neutron.pp
@@ -78,8 +78,8 @@ class eayunstack::upgrade::neutron (
     }
 
     file { 'replace-neutron-l3-agent':
-      path   => '/usr/bin/neutron-l3-agent',
       ensure => file,
+      path   => '/usr/bin/neutron-l3-agent',
       backup => '.bak',
       mode   => '0755',
       owner  => 'root',
@@ -119,8 +119,8 @@ class eayunstack::upgrade::neutron (
     }
 
     file { 'replace-q-agent-cleanup':
-      path => '/usr/bin/q-agent-cleanup.py',
       ensure => file,
+      path => '/usr/bin/q-agent-cleanup.py',
       backup => '.bak',
       mode => '0755',
       owner => 'root',

--- a/puppet/modules/eayunstack/manifests/upgrade/nova.pp
+++ b/puppet/modules/eayunstack/manifests/upgrade/nova.pp
@@ -110,8 +110,8 @@ class eayunstack::upgrade::nova (
       lens    => 'Puppet.lns',
       incl    => '/etc/nova/nova.conf',
       changes => [
-        "rm DEFAULT/cinder_catalog_info",
-        "set cinder/catalog_info volumev2:cinderv2:internalURL",
+        'rm DEFAULT/cinder_catalog_info',
+        'set cinder/catalog_info volumev2:cinderv2:internalURL',
       ],
       onlyif  => 'match cinder/catalog_info[.="volumev2:cinderv2:internalURL"] size < 1',
     }

--- a/puppet/modules/eayunstack/manifests/upgrade/nova.pp
+++ b/puppet/modules/eayunstack/manifests/upgrade/nova.pp
@@ -49,7 +49,7 @@ class eayunstack::upgrade::nova (
         "set cinder/admin_password ${admin_password}",
         "set cinder/admin_tenant_name ${admin_tenant_name}",
       ],
-      onlyif => "match cinder/admin_username[.=\"${admin_username}\"] size < 1",
+      onlyif  => "match cinder/admin_username[.=\"${admin_username}\"] size < 1",
     }
 
     augeas { 'set_reclaim_instance_interval':
@@ -59,7 +59,7 @@ class eayunstack::upgrade::nova (
       changes => [
         "set DEFAULT/reclaim_instance_interval ${reclaim_instance_interval}",
       ],
-      onlyif => "match DEFAULT/reclaim_instance_interval[.=\"${reclaim_instance_interval}\"] size < 1",
+      onlyif  => "match DEFAULT/reclaim_instance_interval[.=\"${reclaim_instance_interval}\"] size < 1",
 
     }
 
@@ -102,7 +102,7 @@ class eayunstack::upgrade::nova (
         "set cinder/admin_password ${admin_password}",
         "set cinder/admin_tenant_name ${admin_tenant_name}",
       ],
-      onlyif => "match cinder/admin_username[.=\"${admin_username}\"] size < 1",
+      onlyif  => "match cinder/admin_username[.=\"${admin_username}\"] size < 1",
     }
 
     augeas { 'change_cinder_catalog_info':
@@ -123,7 +123,7 @@ class eayunstack::upgrade::nova (
       changes => [
         "set DEFAULT/reclaim_instance_interval ${reclaim_instance_interval}",
       ],
-      onlyif => "match DEFAULT/reclaim_instance_interval[.=\"${reclaim_instance_interval}\"] size < 1",
+      onlyif  => "match DEFAULT/reclaim_instance_interval[.=\"${reclaim_instance_interval}\"] size < 1",
 
     }
 

--- a/puppet/modules/eayunstack/manifests/upgrade/nova.pp
+++ b/puppet/modules/eayunstack/manifests/upgrade/nova.pp
@@ -20,7 +20,7 @@ class eayunstack::upgrade::nova (
                               ],
                 ceph       => ['python-novaclient'],
   }
- 
+
   $services = { controller => [
                               'openstack-nova-api', 'openstack-nova-cert', 'openstack-nova-conductor',
                               'openstack-nova-consoleauth', 'openstack-nova-novncproxy',

--- a/puppet/modules/eayunstack/manifests/upgrade/ntp.pp
+++ b/puppet/modules/eayunstack/manifests/upgrade/ntp.pp
@@ -3,8 +3,8 @@ class eayunstack::upgrade::ntp (
 ) {
 
   service { 'ntpd':
-    enable => true,
     ensure => 'running',
+    enable => true,
   }
 
   package { 'ntp':

--- a/puppet/modules/eayunstack/manifests/upgrade/python_eventlet.pp
+++ b/puppet/modules/eayunstack/manifests/upgrade/python_eventlet.pp
@@ -1,4 +1,4 @@
-class eayunstack::upgrade::python-eventlet (
+class eayunstack::upgrade::python_eventlet (
   $fuel_settings,
 ) {
 


### PR DESCRIPTION
With this patchset, no error should be found when run `puppet-lint --no-documentation-check --no-80chars-check --no-variable_scope-check puppet/`.
