### PR TITLE
ansible: a playbook to set neutron agents auto failover

### DIFF
--- a/ansible/roles/neutron/defaults/main.yml
+++ b/ansible/roles/neutron/defaults/main.yml
@@ -1,0 +1,2 @@
+neutron_conf_file: "/etc/neutron/neutron.conf"
+l3_agent_failover_key: "allow_automatic_l3agent_failover"

--- a/ansible/roles/neutron/handlers/main.yml
+++ b/ansible/roles/neutron/handlers/main.yml
@@ -1,0 +1,4 @@
+- name: restart neutron-server
+  service:
+    name: neutron-server
+    state: restarted

--- a/ansible/roles/neutron/tasks/main.yml
+++ b/ansible/roles/neutron/tasks/main.yml
@@ -1,0 +1,16 @@
+- name: set neutron agents failover in conf
+  ini_file:
+    dest: "{{ neutron_conf_file }}"
+    section: "{{ item.section }}"
+    option: "{{ item.option }}"
+    value: "{{ item.value }}"
+  with_items:
+    - section: 'DEFAULT'
+      option: "{{ l3_agent_failover_key }}"
+      value: "{{ neutron_agents_failover }}"
+  notify:
+    - restart neutron-server
+  when:
+    - neutron_agents_failover is defined
+    - neutron_agents_failover == 'True' or neutron_agents_failover == 'False'
+    - action == 'set_neutron_agents_failover'

--- a/ansible/set-neutron-failover.yml
+++ b/ansible/set-neutron-failover.yml
@@ -1,0 +1,9 @@
+- name: set neutron agents failover
+
+  hosts: controller
+
+  serial: 1
+  become: True
+
+  roles:
+    - { role: neutron, action: 'set_neutron_agents_failover' }


### PR DESCRIPTION
It is needed to disable neutron agents automatic failover during the
upgrade procedure. This commit adds an ansible playbook to help toggling
neutron agents automatic failover mechanism.

Usage:
  ansible-playbook set-neutron-failover.yml -e \
      "neutron_agents_failover=True/False"

Signed-off-by: Hunt Xu <mhuntxu@gmail.com>