### PR TITLE
ansible: don't install packages when force_restart_ceph is set.

### DIFF
--- a/ansible/ceph.yml
+++ b/ansible/ceph.yml
@@ -53,7 +53,7 @@
         - obs_load_fuel_facts is defined
 
   roles:
-    - { role: ceph, action: 'install_packages' }
+    - { role: ceph, action: 'install_packages', when: not force_restart_ceph|default('false')|bool }
 
 - name: restart ceph mons
 


### PR DESCRIPTION
Signed-off-by: Zhao Chao <zhaochao1984@gmail.com>