### PR TITLE
ansible: obs default haproxy maxconn is 3000.

### DIFF
--- a/ansible/group_vars/obs.yml
+++ b/ansible/group_vars/obs.yml
@@ -3,4 +3,4 @@ osd_group_name: "obs"
 rgw_group_name: "obs"
 
 eayunobs_haproxy_nb: "12"
-eayunobs_haproxy_maxconn: "4000"
+eayunobs_haproxy_maxconn: "3000"


### PR DESCRIPTION
Signed-off-by: Zhao Chao <zhaochao1984@gmail.com>