### PR TITLE
ansible: use specific dest when fetch fuel facts for obs nodes.

### DIFF
--- a/ansible/ceph.yml
+++ b/ansible/ceph.yml
@@ -17,6 +17,7 @@
 
   vars:
     with_controllers: "{{ ('controller' in groups) and (groups['controller']|length > 0) }}"
+    first_controller_facts: "{{ fuel_facts_fetch_directory }}/{{ groups['controller'][0] }}{{ fuel_facts_file }}"
   hosts:
     - controller
     - ceph-osd
@@ -29,14 +30,15 @@
     - name: fetch fuel facts from the first controller
       fetch:
         src: "{{ fuel_facts_file }}"
-        dest: "{{ fuel_facts_fetch_directory }}"
+        dest: "{{ first_controller_facts }}"
+        flat: "yes"
       run_once: True
       delegate_to: "{{ groups['controller'][0] }}"
       when: with_controllers|bool
 
     - name: load fuel facts on obs nodes
       include_vars:
-        file: "{{ fuel_facts_fetch_directory }}/{{ groups['controller'][0] }}{{ fuel_facts_file }}"
+        file: "{{ first_controller_facts }}"
       register: obs_load_fuel_facts
       when:
         - with_controllers|bool


### PR DESCRIPTION
When ansible-playbook runs with "--limit obs", fetching fuel facts
from the first controller will be triggered by the first obs node.
Then the dest dir will use the hostname of the obs node, which
will lead to a fatal error. Using a specific dest param will fix.

Signed-off-by: Zhao Chao <zhaochao1984@gmail.com>