### PR TITLE
ansible: correctly deal with pcs resource when restarting rgw.

### DIFF
--- a/ansible/ceph.yml
+++ b/ansible/ceph.yml
@@ -114,13 +114,13 @@
       shell: |
         pcs resource manage p_ceph_rgw
       run_once: True
-      delegate_to: "{{ groups['obs'][0] }}"
+      delegate_to: "{{ groups['obs'][-1] }}"
 
     - name: delete pcs httpd resource
       shell: |
         pcs resource show p_httpd-clone && pcs resource delete p_httpd-clone || /bin/true
       run_once: True
-      delegate_to: "{{ groups['obs'][0] }}"
+      delegate_to: "{{ groups['obs'][-1] }}"
 
 
 - name: ensure ceph auth and restart related services


### PR DESCRIPTION
The commands 'pcs resource manage/unmanage/delete' only need run once in
the Ceph RadosGW restarting procedure, and the order of them should be
correct.

Before this patch, the steps in the 'restart ceph rgws' playbook are:
1. the first obs node set ceph-rgw pcs resource unmanged, and restart
   ceph-radosgw, and then set ceph-rgw pcs resource managed, finally
   delete the httpd pcs resource;
2. all other obs nodes restart ceph-radosgw one by one.

The correct steps are:
1. set ceph-rgw pcs resource unmanaged;
2. all obs nodes restart ceph-radosgw one by one;
3. set ceph-rgw pcs resource managed;
4. delete httpd pcs resource.

It may be clearer to use a separate playbook for step 1, and another playbook
for step 3 and step 4. But we can use run_once and delegate to achieve
the same procedure.

Signed-off-by: Zhao Chao <zhaochao1984@gmail.com>