### PR TITLE
neutron: enable stp on integration bridge on compute nodes

### DIFF
--- a/puppet/modules/eayunstack/manifests/upgrade/neutron.pp
+++ b/puppet/modules/eayunstack/manifests/upgrade/neutron.pp
@@ -282,6 +282,15 @@ class eayunstack::upgrade::neutron (
       enable => true,
     }
 
+    # Executions
+
+    exec { 'enable-stp-on-int-br':
+      command  => 'ovs-vsctl set bridge br-int stp_enable=true',
+      path     => '/usr/bin',
+      provider => shell,
+      onlyif   => 'test `ovs-vsctl get bridge br-int stp_enable` = false',
+    }
+
     # Augeases
 
     augeas { 'set-openflow-ew-dvr':


### PR DESCRIPTION
This prevents chance of loops when one instance is connecting to
multiple ports on the same network.

Fixes: redmine #10681

Signed-off-by: Hunt Xu <mhuntxu@gmail.com>