### PR TITLE
puppet: Ceilometer add disk device meter

### DIFF
--- a/puppet/modules/eayunstack/files/pipeline.yaml
+++ b/puppet/modules/eayunstack/files/pipeline.yaml
@@ -25,6 +25,10 @@ sources:
           - "disk.read.requests"
           - "disk.write.bytes"
           - "disk.write.requests"
+          - "disk.device.read.bytes"
+          - "disk.device.read.requests"
+          - "disk.device.write.bytes"
+          - "disk.device.write.requests"
       sinks:
           - disk_bill_sink
     - name: network_bill_source
@@ -77,11 +81,11 @@ sinks:
             parameters:
                 source:
                     map_from:
-                        name: "disk\\.(read|write)\\.(bytes|requests)"
+                        name: "(disk\\.device|disk)\\.(read|write)\\.(bytes|requests)"
                         unit: "(B|request)"
                 target:
                     map_to:
-                        name: "disk.\\1.\\2.rate"
+                        name: "\\1.\\2.\\3.rate"
                         unit: "\\1/s"
                     type: "gauge"
       publishers:


### PR DESCRIPTION
This patch ceilometer add new meter:
- disk.device.read.bytes.rate
- disk.device.write.bytes.rate
- disk.device.read.requests.rate
- disk.device.write.requests.rate

Feature-ES #10741
http://192.168.15.2/issues/10741

Signed-off-by: Yuanbin.Chen <cybing4@gmail.com>