### PR TITLE
puppet: Ceilometer add disk device meter

### DIFF
--- a/puppet/modules/eayunstack/files/pipeline.yaml
+++ b/puppet/modules/eayunstack/files/pipeline.yaml
@@ -23,6 +23,8 @@ sources:
       meters:
           - "disk.read.bytes"
           - "disk.write.bytes"
+          - "disk.device.read.bytes"
+          - "disk.device.write.bytes"
       sinks:
           - disk_bill_sink
     - name: bandwidth_bill_source
@@ -66,11 +68,11 @@ sinks:
             parameters:
                 source:
                     map_from:
-                        name: "disk\\.(read|write)\\.bytes"
+                        name: "(disk\\.device|disk)\\.(read|write)\\.bytes"
                         unit: "(B|request)"
                 target:
                     map_to:
-                        name: "disk.\\1.bytes.rate"
+                        name: "\\1.\\2.bytes.rate"
                         unit: "\\1/s"
                     type: "gauge"
       publishers:


### PR DESCRIPTION
This patch ceilometer add new meter:
- disk.device.read.bytes.rate
- disk.device.write.bytes.rate

Feature-ES #10741
http://192.168.15.2/issues/10741

Signed-off-by: Yuanbin.Chen <cybing4@gmail.com>
(cherry picked from commit f962674aad10001c8d6f6e28c5afe8ce89ab90eb)