### PR TITLE
ansible: fix trove rpc low timeout.

### DIFF
--- a/ansible/roles/trove/templates/trove.conf.j2
+++ b/ansible/roles/trove/templates/trove.conf.j2
@@ -42,7 +42,7 @@ http_mgmt_post_rate = {{ trove_conf.default.http_mgmt_post_rate }}
 network_driver=trove.network.neutron.NeutronDriver
 
 agent_heartbeat_time = {{ trove_conf.default.agent_heartbeat_time }}
-agent_call_low_timeout = {{ trove_conf.default.agent_call_high_timeout }}
+agent_call_low_timeout = {{ trove_conf.default.agent_call_low_timeout }}
 agent_call_high_timeout = {{ trove_conf.default.agent_call_high_timeout }}
 
 reboot_time_out = {{ trove_conf.default.reboot_time_out }}


### PR DESCRIPTION
Trove RPC low timeout was set to high timeout by mistake in commit
52afa076ff1065d0bf0285406d2623cffe7b8053.

Fixes: http://192.168.15.2/issues/10250

Signed-off-by: Zhao Chao <zhaochao1984@gmail.com>