### PR TITLE
PPTP: use the main routing table for PPTP VPN traffic

### DIFF
--- a/puppet/modules/eayunstack/files/ip-down.local
+++ b/puppet/modules/eayunstack/files/ip-down.local
@@ -3,3 +3,5 @@
 VPNSERVICE=$6
 IP=$5
 rm /var/lib/neutron/pptp/$VPNSERVICE/connections/$IP
+ip rule del from $IP lookup main
+ip rule del to $IP lookup main

--- a/puppet/modules/eayunstack/files/ip-up.local
+++ b/puppet/modules/eayunstack/files/ip-up.local
@@ -9,3 +9,5 @@ if [ -f $PIDFILE ]; then
 fi
 echo `lsof -t ${DEVICE}` > $PIDFILE
 chmod 444 $PIDFILE
+ip rule add from $IP lookup main pref 1
+ip rule add to $IP lookup main pref 1


### PR DESCRIPTION
With EayunStack floating IP mechanism, traffic related to each floating
IP will use its own routing table. However this causes problems for PPTP
VPN because the routing table for floating IP doesn't have the
information of the VPN clients.

With this commit, the main routing table is instead used for traffic
related to each specific PPTP VPN client.

Fixes: redmine #11077

Signed-off-by: Hunt Xu <mhuntxu@gmail.com>